### PR TITLE
Fix segfault on wrpkru by filtering the PKRU register

### DIFF
--- a/src/generator/genshared.hpp
+++ b/src/generator/genshared.hpp
@@ -30,6 +30,7 @@ namespace x86Tester::Generator
             case ZYDIS_REGISTER_FLAGS:
             case ZYDIS_REGISTER_EFLAGS:
             case ZYDIS_REGISTER_RFLAGS:
+            case ZYDIS_REGISTER_PKRU:
                 return true;
         }
         return false;


### PR DESCRIPTION
Hi, I've got this crash on one of the machines:

```
[1021/1040  98.2%] wrpkru
Building "wrpkru" instruction combinations, completed in 0.00s.
Total instructions: 1
Generating tests            0% [                                        ][1]    2992490 segmentation fault (core dumped)  ./build/x86Tester-cli
```

Following is AI's rationale & fix, not sure it's accurate, but it allowed me finishing without segfaulting.

> WRPKRU writes the PKRU register, which Zydis reports as a written register operand. captureOutputs() iterates getRegsModified() and calls ctx.getRegBytes(bigReg) for each, then range-constructs an sfl::small_vector from [begin, begin + width). For PKRU, getContextReg() has no case: it falls through to assert(false) / return {}. In release/RelWithDebInfo builds NDEBUG strips the assert, so it returns an empty span whose data() is nullptr, and the small_vector construction dereferences address 0 -> SIGSEGV.

> PKRU lives in the XSAVE area, which the ptrace harness never reads (PTRACE_GETFPREGS only covers user_fpregs_struct), so there is no meaningful state to capture. Filter it in isRegFiltered() alongside RIP and the FLAGS variants, which keeps it out of both the read and modified register sets. wrpkru now generates cleanly (0 test cases) instead of crashing the whole run.